### PR TITLE
Use Blaseball.com API to find games

### DIFF
--- a/game_finder/command.py
+++ b/game_finder/command.py
@@ -18,7 +18,7 @@ def main(sysargs = sys.argv[1:]):
     p = configargparse.ArgParser()
 
     # These are safe for command line usage (no accent in Dale)
-    LEAGUES, DIVISIONS, ALLTEAMS = get_league_division_team_data()
+    _, _, ALLTEAMS = get_league_division_team_data()
 
     p.add('-v',
           '--version',
@@ -34,50 +34,32 @@ def main(sysargs = sys.argv[1:]):
           help='config file path')
 
     # Pick our team
-    h = p.add_mutually_exclusive_group()
-    h.add('--team',
+    p.add('--team',
           choices=ALLTEAMS,
           action='append',
           help='Specify our team (use flag multiple times for multiple teams)')
-    h.add('--division',
-          choices=DIVISIONS,
-          action='append',
-          help='Specify our division (use flag multiple times for multiple divisions)')
-    h.add('--league',
-          choices=LEAGUES,
-          action='append',
-          help='Specify our league')
 
-    # Pick versus team
-    k = p.add_mutually_exclusive_group()
-    k.add('--versus-team',
+    p.add('--versus-team',
           choices=ALLTEAMS,
           action='append',
           help='Specify versus team (use flag multiple times for multiple teams)')
-    k.add('--versus-division',
-          choices=DIVISIONS,
-          action='append',
-          help='Specify versus division (use flag multiple times for multiple divisions)')
-    k.add('--versus-league',
-          choices=LEAGUES,
-          action='append',
-          help='Specify versus league')
 
     # Specify what season data to view
     p.add('--season',
-          required=False,
+          required=True,
           action='append',
-          help='Specify season (use flag multiple times for multiple seasons, no --seasons flag means all data)')
+          help='Specify season (use flag multiple times for multiple seasons)')
+    # Season is required, but day is not
     p.add('--day',
           required=False,
           action='append',
           help='Specify day (use flag multiple times for multiple days, no --days flag means all days)')
 
-    # Restrict to postseason data only
-    p.add('--postseason',
+    # Restrict to playoffs data only
+    p.add('--playoffs',
           action='store_true',
           default=False,
-          help='Restrict game IDs to postseason games only')
+          help='Restrict game IDs to playoffs games only')
 
     # format
     p.add('--text',
@@ -106,40 +88,10 @@ def main(sysargs = sys.argv[1:]):
         print(_program, __version__)
         sys.exit(0)
 
-    # If the user specified a division or a league,
-    # turn that into a list of teams for them
-    if options.division:
-        divteams = []
-        for div in options.division:
-            divteams += division_to_teams(div)
-        options.team = divteams
-        options.division = None
-    if options.league:
-        leateams = []
-        for lea in options.league:
-            leateams += league_to_teams(lea)
-        options.team = leateams
-        options.league = None
-    # Same for versus
-    if options.versus_division:
-        vdivteams = []
-        for div in options.versus_division:
-            vdivteams += division_to_teams(div)
-        options.versus_team = vdivteams
-        options.versus_division = None
-    if options.versus_league:
-        vleateams = []
-        for lea in options.versus_league:
-            vleateams += league_to_teams(lea)
-        options.versus_team = vleateams
-        options.versus_league = None
-
-    # If nothing was supplied for our team/division/league, use all teams
-    if not options.team and not options.division and not options.league:
+    # If nothing was supplied for teams options, use all teams
+    if not options.team:
         options.team = ALLTEAMS
-
-    # If nothing was supplied for versus team/division/league, use all teams
-    if not options.versus_team and not options.versus_division and not options.versus_league:
+    if not options.versus_team:
         options.versus_team = ALLTEAMS
 
     # If nothing was provided for seasons, set it to 'all'

--- a/game_finder/finderdata.py
+++ b/game_finder/finderdata.py
@@ -1,0 +1,47 @@
+import requests
+import json
+from functools import lru_cache
+
+
+class ApiError(Exception):
+    pass
+
+
+class NoMatchingGames(Exception):
+    pass
+
+
+class RawDayData(object):
+    """
+    This class uses the /games api endpoint and passes
+    a season and a day, which returns a list of json objects,
+    one per game (10 total in regular season).
+
+    This object strips out the necessary information,
+    making it available to the formatter object.
+    """
+    ENDPOINT = "https://blaseball.com/database/games?day={day}&season={season}"
+
+    def __init__(self, season, day):
+        url = self.ENDPOINT.format(season=season, day=day)
+        resp = requests.get(url)
+        if resp.status_code != 200:
+            raise ApiError()
+        try:
+            self.games_data = resp.json()
+        except JSONDecodeError:
+            raise NoMatchingGames()
+        if len(self.games_data)==0:
+            raise NoMatchingGames()
+
+    def get_games_by_team(self, teams, versus_teams):
+        team_data = []
+        for game in self.games_data:
+            b1 = (game['homeTeamNickname'] in teams) and (game['awayTeamNickname'] in versus_teams)
+            b2 = (game['awayTeamNickname'] in teams) and (game['homeTeamNickname'] in versus_teams)
+            if b1 or b2:
+                team_data.append(game)
+        return team_data
+
+
+

--- a/game_finder/formatter.py
+++ b/game_finder/formatter.py
@@ -1,118 +1,57 @@
-import blaseball_core_game_data as gd
-from .util import sanitize_dale, desanitize_dale
 import os
 import time
 import json
+from .util import sanitize_dale, desanitize_dale
+from .finderdata import RawDayData, NoMatchingGames
 
-class NoGamesException(Exception):
-    pass
 
 class BaseFormatter(object):
     def __init__(self, options):
-        """Load the data set"""
-        self.data = json.loads(gd.get_games_data())
+        """Extract options"""
         self.options = options
-
-        # user provides one-indexed days and seasons
-        # data has zero-indexed days and seasons
-        if 'all' not in options.season:
-            self.seasons = [str(int(j)-1) for j in options.season]
-
+        self.teams = options.team
+        self.versus_teams = options.versus_team
+        self.seasons = options.season
         if options.day:
-            self.days = [str(int(j)-1) for j in options.day]
+            self.days = options.day
         else:
-            self.days = None
+            self.days = range(1,99+1)
+        self.playoffs = options.playoffs
+        if self.playoffs:
+            # Presumably, the max day we can reach in blaseball
+            # is 15 (5 games per series times 3 rounds)
+            # Add 3 just to be sure
+            MAXDAYS = 115
+            self.days = range(100,MAXDAYS+1+3)
 
-        self.our_team = options.team
-        self.their_team = options.versus_team
-
-        # data is a list of dictionaries
-        # keys:
-        # - awayOdds
-        # - awayPitcherName
-        # - awayScore
-        # - awayTeamEmoji
-        # - awayTeamName
-        # - awayTeamNickname
-        # - day
-        # - homeOdds
-        # - homePitcherName
-        # - homeScore
-        # - homeTeamEmoji
-        # - homeTeamName
-        # - homeTeamNickname
-        # - id
-        # - isPostseason
-        # - losingOdds
-        # - losingPitcherName
-        # - losingScore
-        # - losingTeamEmoji
-        # - losingTeamName
-        # - losingTeamNickname
-        # - runDiff
-        # - season
-        # - shame
-        # - whoWon
-        # - winningOdds
-        # - winningPitcherName
-        # - winningScore
-        # - winningTeamEmoji
-        # - winningTeamName
-        # - winningTeamNickname
-
-        # use list comprehensions to do fast filtering
-        # but first, write the loops explicitly
-
-        # UUUURRRRRGGGGGGGGGGGG for some reason all the Dale 
-        # are getting switched from unicode format (when we import)
-        # to plain string format (below). BUT HOW???
-
-        # Seasons filter
-        if 'all' not in options.season:
-            new_data = []
-            for game in self.data:
-                if str(game['season']) in self.seasons:
-                    new_data.append(game)
-            self.data = new_data
-
-        # Days filter
-        if self.days is not None:
-            new_data = []
-            for game in self.data:
-                if str(game['day']) in self.days:
-                    new_data.append(game)
-            self.data = new_data
-
-        # Teams filter
-        new_data = []
-        for game in self.data:
-            b1 = lambda g: g['awayTeamNickname'] in self.our_team and g['homeTeamNickname'] in self.their_team
-            b2 = lambda g: g['homeTeamNickname'] in self.our_team and g['awayTeamNickname'] in self.their_team 
-            if b1(game) or b2(game):
-                new_data.append(game)
-        self.data = new_data
-
-        # Postseason filter
-        if options.postseason:
-            new_data = []
-            for game in self.data:
-                if game['isPostseason']:
-                    new_data.append(game)
-            self.data = new_data
-
+    def extract(self):
+        games = []
+        for season in self.seasons:
+            for day in self.days:
+                if self.playoffs:
+                    try:
+                        raw_data = RawDayData(season, day)
+                    except NoMatchingGames:
+                        continue
+                else:
+                    raw_data = RawDayData(season, day)
+                team_data = raw_data.get_games_by_team(self.teams, self.versus_teams)
+                games += team_data
+        return games
 
 class JsonFormatter(BaseFormatter):
     def output(self):
-        data_short = []
-        for game in self.data:
-            game_short = {}
-            short_keys = ['awayOdds','awayScore','awayTeamNickname','day','homeOdds','homeScore','homeTeamNickname','id','isPostseason','whoWon','shame','season','runDiff']
-            for k in short_keys:
-                game_short[k] = game[k]
-            data_short.append(game_short)
-        print(json.dumps(data_short, indent=4))
+        games_list = []
+        team_data = self.extract()
+        for game in self.extract().next():
+            games_list.append(game)
+        print(json.dumps(games_list, indent=4))
 
 class TextFormatter(BaseFormatter):
     def output(self):
-        for game in self.data:
+        for game in self.extract():
             print(game['id'])
+
+# Formatter creates one RawDayData object per day
+# Use the filters and figure out what days need to be included.
+

--- a/game_finder/util.py
+++ b/game_finder/util.py
@@ -134,5 +134,5 @@ class CaptureStdout(object):
         sys.stdout = self._stdout
 
     def __repr__(self):
-        """When this context manager is printed, it looks like the game ID string"""
+        """When this context manager is printed, it returns the captured stdout"""
         return self.value

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-blaseball-core-game-data
+requests
 configargparse


### PR DESCRIPTION
This is slower but doesn't use the blaseball-core-game-data package, meaning we can get games as soon as they are published on blaseball.com (within a few hours), instead of waiting until the data is in blaseball-core-game-data (happens at end of season). Also removes `--league` and `--division` flags.

This may have an issue specifying team/versus team, which probably means this approach won't work.